### PR TITLE
Fixed bug duplicate id on mongo when adding new notes

### DIFF
--- a/pkg/storage/mongo/db.go
+++ b/pkg/storage/mongo/db.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Note struct {
-	Id          primitive.ObjectID `bson:"_id"`
+	Id          primitive.ObjectID `bson:"_id,omitempty"`
 	Tags        []string           `bson:"tags"`
 	Command     string             `bson:"command"`
 	Description string             `bson:"description"`


### PR DESCRIPTION
Getting duplicate id key when adding new notes on mongo.
Apparently we need to add omitempty so it can generate new ids.